### PR TITLE
fix: add alternative w/ less CSS for focus

### DIFF
--- a/examples/control-elements/media-chrome-menu-button.html
+++ b/examples/control-elements/media-chrome-menu-button.html
@@ -18,6 +18,7 @@
       margin-inline: auto;
       max-width: 640px;
       height: 5000px;
+      --media-control-padding: 5px;
     }
 
     [disabled] {
@@ -76,12 +77,26 @@
       </video>
       <media-poster-image slot="poster" src="https://d2zihajmogu5jn.cloudfront.net/elephantsdream/poster.png"></media-poster-image>
       <media-control-bar>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
         <media-play-button></media-play-button>
         <media-seek-backward-button seek-offset="15"></media-seek-backward-button>
         <media-seek-forward-button seek-offset="15"></media-seek-forward-button>
         <media-mute-button></media-mute-button>
-        <media-volume-range></media-volume-range>
-        <media-time-range></media-time-range>
         <media-time-display show-duration remaining></media-time-display>
         <media-captions-button></media-captions-button>
         <media-chrome-menu-button aria-label="captions menu button">
@@ -100,6 +115,26 @@
         <media-chrome-menu-button aria-label="captions menu button">
           <media-captions-button default-showing slot="button"></media-captions-button>
           <media-captions-listbox slot="listbox" ></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
+        </media-chrome-menu-button>
+        <media-chrome-menu-button aria-label="captions menu button">
+          <media-captions-button default-showing slot="button"></media-captions-button>
+          <media-captions-listbox slot="listbox"></media-captions-listbox>
         </media-chrome-menu-button>
       </media-control-bar>
     </media-controller>

--- a/src/js/experimental/media-chrome-listitem.js
+++ b/src/js/experimental/media-chrome-listitem.js
@@ -11,6 +11,7 @@ template.innerHTML = `
     padding: 0.5em;
     margin: 0em;
     cursor: pointer;
+    white-space: nowrap;
   }
 
   ::slotted:not(:focus-visible) {

--- a/src/js/experimental/media-chrome-listitem.js
+++ b/src/js/experimental/media-chrome-listitem.js
@@ -11,7 +11,6 @@ template.innerHTML = `
     padding: 0.5em;
     margin: 0em;
     cursor: pointer;
-    white-space: nowrap;
   }
 
   ::slotted:not(:focus-visible) {

--- a/src/js/experimental/media-chrome-menu-button.js
+++ b/src/js/experimental/media-chrome-menu-button.js
@@ -8,37 +8,29 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
   :host {
-    display: contents;
-  }
-
-  [name="listbox"] {
-    display: flex;
-    width: 0;
+    display: inline-block;
     position: relative;
-  }
-
-  [name="listbox"][hidden] {
-    display: none;
   }
 
   [name="listbox"]::slotted(*),
   media-chrome-listbox {
     position: absolute;
+    left: 0;
     bottom: 100%;
     max-height: 300px;
     overflow: hidden auto;
   }
   </style>
 
-  <slot name="listbox" hidden>
-    <media-chrome-listbox id="listbox" part="listbox">
-      <slot></slot>
-    </media-chrome-listbox>
-  </slot>
   <slot name="button">
     <media-chrome-button aria-haspopup="listbox">
       <slot name="button-content"></slot>
     </media-chrome-button>
+  </slot>
+  <slot name="listbox" hidden>
+    <media-chrome-listbox id="listbox" part="listbox">
+      <slot></slot>
+    </media-chrome-listbox>
   </slot>
 `;
 

--- a/src/js/experimental/media-chrome-menu-button.js
+++ b/src/js/experimental/media-chrome-menu-button.js
@@ -8,8 +8,9 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
   :host {
-    display: inline-block;
+    display: inline-flex;
     position: relative;
+    flex-shrink: .5;
   }
 
   [name="listbox"]::slotted(*),

--- a/src/js/experimental/media-chrome-menu-button.js
+++ b/src/js/experimental/media-chrome-menu-button.js
@@ -153,10 +153,8 @@ class MediaChromeMenuButton extends window.HTMLElement {
 
     const boundsRect = bounds.getBoundingClientRect();
     const listboxRect = this.#listbox.getBoundingClientRect();
-    const offset = (listboxRect.width - buttonRect.width) / 2;
-    let position = -offset;
-    position -= Math.max(buttonRect.x + offset + buttonRect.width - boundsRect.right, 0);
-    position += Math.max(-buttonRect.x + offset + boundsRect.x, 0);
+    let position = -Math.max(buttonRect.x + listboxRect.width - boundsRect.right, 0);
+
 
     this.#listbox.style.transform = `translateX(${position}px)`;
   }


### PR DESCRIPTION
edit: updated `media-chrome-menu-button` to have dimensions.

I don't really see any issues w/ focus. why was that extra CSS needed?
