### PR TITLE
fix: remove default handleClick in selectmenu

### DIFF
--- a/src/js/experimental/media-chrome-select-menu.js
+++ b/src/js/experimental/media-chrome-select-menu.js
@@ -36,8 +36,6 @@ template.innerHTML = `
 `;
 
 class MediaChromeSelectMenu extends window.HTMLElement {
-  #handleClick;
-  #handleChange;
   #enabledState = true;
   #button;
   #buttonSlot;
@@ -61,9 +59,6 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     this.nativeEl = buttonHTML;
 
     shadow.appendChild(buttonHTML);
-
-    this.#handleClick = this.#handleClick_.bind(this);
-    this.#handleChange = this.#handleChange_.bind(this);
 
     this.#button = this.shadowRoot.querySelector('media-chrome-button');
     this.#listbox = this.shadowRoot.querySelector('media-chrome-listbox');
@@ -104,11 +99,11 @@ class MediaChromeSelectMenu extends window.HTMLElement {
     });
   }
 
-  #handleClick_() {
+  #handleClick = () => {
     this.#toggle();
   }
 
-  #handleChange_() {
+  #handleChange = () => {
     this.#toggle();
   }
 
@@ -166,6 +161,7 @@ class MediaChromeSelectMenu extends window.HTMLElement {
 
   enable() {
     this.#button.removeAttribute('disabled');
+    this.#button.handleClick = undefined;
     this.#button.addEventListener('click', this.#handleClick);
     this.#toggleExpanded();
     this.#listbox.addEventListener('change', this.#handleChange);

--- a/src/js/media-captions-button.js
+++ b/src/js/media-captions-button.js
@@ -113,10 +113,6 @@ class MediaCaptionsButton extends MediaChromeButton {
   }
 
   handleClick() {
-    const MediaChromeSelectMenu = window.customElements.get('media-chrome-select-menu');
-    // do nothing if parent is an instance of MediaChromeSelectMenu
-    if (this.parentElement instanceof MediaChromeSelectMenu) return;
-
     toggleSubsCaps(this);
   }
 }

--- a/src/js/media-chrome-button.js
+++ b/src/js/media-chrome-button.js
@@ -92,7 +92,7 @@ class MediaChromeButton extends window.HTMLElement {
   }
 
   #clickListener = (e) => {
-    this.handleClick(e);
+    this.handleClick?.(e);
   }
 
   // NOTE: There are definitely some "false positive" cases with multi-key pressing,
@@ -104,7 +104,7 @@ class MediaChromeButton extends window.HTMLElement {
       return;
     }
 
-    this.handleClick(e);
+    this.handleClick?.(e);
   }
 
   #keydownListener = (e) => {


### PR DESCRIPTION
did some quick digging into this one, turns out the public method this.handleClick is re-called each time on click so it's fine to set it to undefined once it's part of selectmenu. 

might have to restore it once the button is removed from selectmenu.

or setting a new property to condition in handleClick would do it too I guess, it's pretty much the same.

